### PR TITLE
Switch to LTS 15

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.27
+resolver: lts-15.5
 allow-newer: true
 extra-deps:
 # mu
@@ -17,14 +17,14 @@ extra-deps:
 # dependencies of mu
 - http2-client-0.9.0.0
 - http2-client-grpc-0.8.0.0
-- http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.4.0.1
+- http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
-- language-protobuf-1.0.1
-- language-avro-0.1.3.1
+- warp-grpc-0.4.0.1
+- hw-kafka-client-3.0.0
+- hw-kafka-conduit-2.6.0
+- git: https://github.com/hasura/graphql-parser-hs.git
+  commit: 1380495a7b3269b70a7ab3081d745a5f54171a9c
 - avro-0.5.1.0
-- HasBigDecimal-0.1.1
-- optics-core-0.2
-- indexed-profunctors-0.1
+- language-avro-0.1.3.1
 


### PR DESCRIPTION
The Docker image should also be updated to use that LTS. If it's not done, it still works, but many things need to be rebuilt, and the point of using te Stack Docker is not to do that.